### PR TITLE
Display poll error message if debugpy is not installed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -132,7 +132,12 @@ class StartDebugServer(Operator):
 
     @classmethod
     def poll(cls, context):
-        return is_debugpy_installed()
+        if not is_debugpy_installed():
+            cls.poll_message_set(
+                "Couldn't find \"debugpy\". Try to install it from the addon's preferences."
+            )
+            return False
+        return True
 
     def execute(self, context):
         addon_prefs = context.preferences.addons[__package__].preferences

--- a/__init__.py
+++ b/__init__.py
@@ -134,7 +134,7 @@ class StartDebugServer(Operator):
     def poll(cls, context):
         if not is_debugpy_installed():
             cls.poll_message_set(
-                "Couldn't find \"debugpy\". Try to install it from the addon's preferences."
+                "Couldn't find \"debugpy\". Try to install it from the add-on's preferences."
             )
             return False
         return True


### PR DESCRIPTION
Example:
![image](https://github.com/hextantstudios/hextant_python_debugger/assets/9417531/d8e7ad84-ce12-40fc-8107-3044de92864a)
