### PR TITLE
Add Auto Start per file, Add Panel to Workspace

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,9 +53,34 @@ To debug your Blender add-on using Visual Studio Code, a few things need to be d
   * This will create and open a `.vscode/launch.json` file in your add-on projects folder.
 
     * Copy and paste the `localRoot` value to the `remoteRoot` and save and close the file:
+
       ```json
       "localRoot": "${workspaceFolder}",
       "remoteRoot": "${workspaceFolder}"
+      ```
+
+      Full example:
+      ```json
+        {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "name": "Python Debugger: Remote Attach",
+              "type": "python",
+              "request": "attach",
+              "connect": {
+                "host": "localhost",
+                "port": 5678
+              },
+              "pathMappings": [
+                {
+                  "localRoot": "${workspaceFolder}",
+                  "remoteRoot": "${workspaceFolder}"
+                }
+              ]
+            },
+          ]
+        }
       ```
 
 You should now be able to debug your add-on as needed by doing the following:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -104,7 +104,7 @@ You should now be able to debug your add-on as needed by doing the following:
 
 ## Known Issues
 
-* *None currently.*
+* TODO mark file as modified after add auto-start debugging
 
 ## License
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -85,6 +85,9 @@ You should now be able to debug your add-on as needed by doing the following:
 
 * From Blender's main menu, click: *{Blender Icon} / System / Start Debug Server*
   * Note that this only needs to be done once per Blender execution. If the menu appears disabled, the `debugpy` package needs to be installed from the add-on's preferences.
+  * Or from sidebar, press `n` then "Tool" tab look at Workspace panel, you will find Debug panel
+  * You can save auto start debug with the file, if you opened that file again debug will start automatically
+
 * From Visual Studio:
   * Click *File / Open / Folder* and open the folder containing your add-on.
   * Click *Debug / Attach to Process* (`Ctrl + Alt + P`)

--- a/__init__.py
+++ b/__init__.py
@@ -275,8 +275,6 @@ def register():
 
 def unregister():
     _unregister()
-    bpy.app.handlers.load_post.remove(debugpy_load_handler)
-
     # Remove System menu entry
     bpy.types.TOPBAR_MT_blender_system.remove(start_remote_debugger_menu)
 

--- a/__init__.py
+++ b/__init__.py
@@ -138,6 +138,10 @@ def popup(message="", title="Message Box", icon="INFO"):
     bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
     return
 
+def is_blender_debug_mode():
+    """Check if Blender was started with --debug or --debug-all"""
+    return any(arg in sys.argv for arg in ('--debug', '--debug-all'))
+
 # Starts the debug server for Python scripts.
 class StartDebugServer(Operator):
     """Starts the remote debug server (debugpy) for Python scripts.
@@ -286,7 +290,7 @@ def stop_remote_debugger_menu(self, context):
 @persistent
 def debugpy_load_handler(dummy):
     ws = bpy.context.workspace
-    if ws.get("auto_start_debugpy") and ws["auto_start_debugpy"]:
+    if is_blender_debug_mode() or (ws.get("auto_start_debugpy") and ws["auto_start_debugpy"]):
         bpy.ops.script.start_debug_server()
         popup("Remote python debugger auto started.", "Debug debugpy")
 

--- a/__init__.py
+++ b/__init__.py
@@ -131,6 +131,13 @@ class UninstallDebugpy(Operator):
 
 DEBUGPY_LISTENING = False
 
+def popup(message="", title="Message Box", icon="INFO"):
+    def draw(self, context):
+        self.layout.label(text=message)
+
+    bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
+    return
+
 # Starts the debug server for Python scripts.
 class StartDebugServer(Operator):
     """Starts the remote debug server (debugpy) for Python scripts.
@@ -175,7 +182,7 @@ class StartDebugServer(Operator):
                 f"Remote python debugger failed to start (or already started) on port {port} : {str(e)}")
             return {'FINISHED'}
 
-        self.report({'INFO'}, f"Remote python debugger started on port {port}, and this file is set to auto start debug.")
+        self.report({'INFO'}, f"Remote python debugger started on port {port}.")
         return {'FINISHED'}
 
 
@@ -281,6 +288,7 @@ def debugpy_load_handler(dummy):
     ws = bpy.context.workspace
     if ws.get("auto_start_debugpy") and ws["auto_start_debugpy"]:
         bpy.ops.script.start_debug_server()
+        popup("Remote python debugger auto started.", "Debug debugpy")
 
 #
 # Registration


### PR DESCRIPTION
* Using --debug to start debugger from command line of blender , use `blender --debug`
* Add debug button in Sidebar, Tool, Workspace
* Add `auto start debug` option to the workspace(file), when load file it start debugpy automatically, this useful to start debugging steps
